### PR TITLE
Changing child insert processing order to 'last-to-first'

### DIFF
--- a/src/layout/shadowdom.ts
+++ b/src/layout/shadowdom.ts
@@ -265,10 +265,12 @@ export class ShadowDom {
         this.setClass(shadowNode, FinalClassName);
 
         // Process children
-        let nextChild = addedNode.firstChild;
+        // We use insertBefore to insert nodes into the shadowDom, so the right sibling needs to be inserted
+        // before the left sibling. For that reason we process children from last to first (right to left)
+        let nextChild = addedNode.lastChild;
         while (nextChild) {
           this.applyInsert(nextChild, addedNode, nextChild.previousSibling, nextChild.nextSibling, true);
-          nextChild = nextChild.nextSibling;
+          nextChild = nextChild.previousSibling;
         }
       } else {
         this.moveShadowNode(addedNodeIndex, parentIndex, getNodeIndex(nextSibling));

--- a/test/layout.ts
+++ b/test/layout.ts
@@ -134,6 +134,36 @@ describe("Layout Tests", () => {
     }
   });
 
+  it("checks that moving two known nodes to a new location such that they are siblings works correctly", (done) => {
+    let observer = new MutationObserver(callback);
+    observer.observe(document, { childList: true, subtree: true });
+
+    // Move multiple nodes from one parent to another and observe Clarity events
+    let stopObserving = observeEvents(LayoutEventName);
+    let dom = document.getElementById("clarity");
+    let backup = document.getElementById("backup");
+    let div = document.createElement("div");
+
+    dom.parentElement.appendChild(div);
+    div.appendChild(dom);
+    div.appendChild(backup);
+
+    function callback() {
+      observer.disconnect();
+
+      // Following jasmine feature fast forwards the async delay in setTimeout calls
+      triggerSend();
+
+      // Uncompress recent data from mutations
+      let events = stopObserving();
+
+      assert.equal(events.length, 3);
+
+      // Explicitly signal that we are done here
+      done();
+    }
+  });
+
   //  Currently we stopped capturing CSS rule modifications, so disabling this test
   //  Keeping it in code to use it again, once CSS rule modification capturing is restored
   //

--- a/test/layout.ts
+++ b/test/layout.ts
@@ -142,11 +142,11 @@ describe("Layout Tests", () => {
     let stopObserving = observeEvents(LayoutEventName);
     let dom = document.getElementById("clarity");
     let backup = document.getElementById("backup");
-    let div = document.createElement("div");
+    let span = document.createElement("span");
 
-    dom.parentElement.appendChild(div);
-    div.appendChild(dom);
-    div.appendChild(backup);
+    dom.parentElement.appendChild(span);
+    span.appendChild(dom);
+    span.appendChild(backup);
 
     function callback() {
       observer.disconnect();
@@ -158,6 +158,17 @@ describe("Layout Tests", () => {
       let events = stopObserving();
 
       assert.equal(events.length, 3);
+
+      assert.equal(events[0].state.action, 0);
+      assert.equal(events[0].state.tag, "SPAN");
+
+      assert.equal(events[1].state.action, 3);
+      assert.equal(events[1].state.index, dom[NodeIndex]);
+      assert.equal(events[1].state.next, backup[NodeIndex]);
+
+      assert.equal(events[2].state.action, 3);
+      assert.equal(events[2].state.index, backup[NodeIndex]);
+      assert.equal(events[2].state.next, null);
 
       // Explicitly signal that we are done here
       done();


### PR DESCRIPTION
This is needed because we insert items into the shadowDom using insertBefore API (when the right sibling is known), so we want to place the right sibling in the correct location, before inserting the left sibling.