### PR TITLE
Pass raw string to upload handlers (instead of stringified)

### DIFF
--- a/test/core.ts
+++ b/test/core.ts
@@ -77,7 +77,7 @@ describe("Functional Tests", () => {
     done();
   });
 
-  it("validates that dropped payloads are re-sent through the next request's 'onSucess' callback", (done) => {
+  it("validates that dropped payloads are re-sent through the next request's 'onSuccess' callback", (done) => {
     let stopObserving = observeEvents();
     let mockFailure = true;
     let uploadInvocationCount = 0;
@@ -309,6 +309,7 @@ describe("Functional Tests", () => {
   });
 
   function mockUploadHandler(payload: string) {
+    payload = JSON.stringify(payload);
     let xhr = new XMLHttpRequest();
     xhr.open("POST", config.uploadUrl);
     xhr.setRequestHeader("Content-Type", "application/json");


### PR DESCRIPTION
We used to pass a stringified (quoted) string to the upload handler, so that visualization can handle it properly. Now that we have custom upload handler support, upload handlers should receive raw data and our default handler can stringify the payload, if needed, for visualization.