### PR TITLE
Remove typings from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "clarity-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
   "main": "build/clarity.js",
-  "typings": "clarity.d.ts",
   "keywords": [
     "clarity",
     "Microsoft",

--- a/src/core.ts
+++ b/src/core.ts
@@ -136,7 +136,7 @@ function envelope(): IEnvelope {
     clarityId: cid,
     impressionId,
     url: top.location.href,
-    version: "0.1.2",
+    version: "0.1.3",
     time: Math.round(getPageContextBasedTimestamp()),
     sequenceNumber: sequence++
   };


### PR DESCRIPTION
Specifying typings in package.json confuse typescript to lookup d.ts file before the actual module. We will revisit typings later, starting simple for now.