### PR TITLE
Bug fix and monitoring scroll for overflow hidden elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,7 +4,7 @@ import { config } from "./config";
 import getPlugin from "./plugins";
 import { debug, getCookie, guid, isNumber, mapProperties, setCookie } from "./utils";
 
-const version = "0.1.13";
+const version = "0.1.14";
 const ImpressionAttribute = "data-iid";
 const UserAttribute = "data-cid";
 const Cookie = "ClarityID";

--- a/src/plugins/layout.ts
+++ b/src/plugins/layout.ts
@@ -205,16 +205,11 @@ export default class Layout implements IPlugin {
       return;
     }
 
-    // Check if scroll is possible, and if so, bind to scroll event
-    let styles = window.getComputedStyle(element);
-    let scrollPossible = (layoutState.layout !== null
-                          && (styles["overflow-x"] === "auto"
-                              || styles["overflow-x"] === "scroll"
-                              || styles["overflow-y"] === "auto"
-                              || styles["overflow-y"] === "scroll"));
+    let scrollPossible = (layoutState.layout
+                          && ("scrollX" in layoutState.layout
+                          || "scrollY" in layoutState.layout));
+
     if (scrollPossible) {
-      layoutState.layout.scrollX = Math.round(element.scrollLeft);
-      layoutState.layout.scrollY = Math.round(element.scrollTop);
       bind(element, "scroll", this.layoutHandler.bind(this, element, Source.Scroll));
       this.watchList[layoutState.index] = true;
     }

--- a/src/plugins/layout/stateprovider.ts
+++ b/src/plugins/layout/stateprovider.ts
@@ -89,12 +89,25 @@ export function createElementLayoutState(element: Element): IElementLayoutState 
 
   elementState.layout = null;
   if (rect) {
+    let styles = window.getComputedStyle(element);
+
     elementState.layout = {
       x: Math.round(rect.left),
       y: Math.round(rect.top),
       width: Math.round(rect.width),
       height: Math.round(rect.height)
     };
+
+    // Check if scroll is possible, and if so, bind to scroll event
+    if (styles["overflow-x"] === "auto"
+                              || styles["overflow-x"] === "scroll"
+                              || styles["overflow-x"] === "hidden"
+                              || styles["overflow-y"] === "auto"
+                              || styles["overflow-y"] === "scroll"
+                              || styles["overflow-y"] === "hidden") {
+      elementState.layout.scrollX = Math.round(element.scrollLeft);
+      elementState.layout.scrollY = Math.round(element.scrollTop);
+    }
   }
 
   return elementState;

--- a/src/plugins/layout/stateprovider.ts
+++ b/src/plugins/layout/stateprovider.ts
@@ -98,7 +98,7 @@ export function createElementLayoutState(element: Element): IElementLayoutState 
       height: Math.round(rect.height)
     };
 
-    // Check if scroll is possible, and if so, bind to scroll event
+    // Check if scroll is possible
     if (styles["overflow-x"] === "auto"
                               || styles["overflow-x"] === "scroll"
                               || styles["overflow-x"] === "hidden"


### PR DESCRIPTION
This code change fixes the bug where we were only setting scroll position the first time element was inserted. If we received a follow-up mutation, then we lost the existing scroll position even though we continued to watch the element for scroll updates. If at this time scroll event happened, we would try to check if distance is large enough for us to send the event back and we would see previous scroll position as NaN. 

The other fix in this code change is to also watch scrolling for overflow:hidden elements.