### PR TITLE
Look for scroll changes on dom updates

### DIFF
--- a/clarity.d.ts
+++ b/clarity.d.ts
@@ -150,9 +150,7 @@ interface ICompressedBatchMessage extends IWorkerMessage {
 /* ############   LAYOUT   ############# */
 /* ##################################### */
 
-type NumberJson = {
-  [key: number]: NumberJson;
-};
+type NumberJson = Array<number | number[]>;
 
 interface IShadowDomNode extends HTMLDivElement {
   node: Node; /* Reference to the node in the real DOM */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/src/plugins/layout.ts
+++ b/src/plugins/layout.ts
@@ -167,15 +167,16 @@ export default class Layout implements IPlugin {
   private createEventState<T extends ILayoutEventInfo>(eventInfo: T): ILayoutState {
     let node = eventInfo.node;
     let layoutState: ILayoutState = createLayoutState(node, this.shadowDom);
+
     switch (eventInfo.action) {
       case Action.Insert:
         // Watch element for scroll and input change events
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          this.watch(node as Element, layoutState as IElementLayoutState);
-        }
+        this.watch(node, layoutState);
         layoutState.action = Action.Insert;
         break;
       case Action.Update:
+        // Watch element for scroll and input change events
+        this.watch(node, layoutState);
         layoutState.action = Action.Update;
         break;
       case Action.Remove:
@@ -198,13 +199,15 @@ export default class Layout implements IPlugin {
     return layoutState;
   }
 
-  private watch(element: Element, layoutState: IElementLayoutState) {
+  private watch(node: Node, nodeLayoutState: ILayoutState) {
 
     // We only wish to watch elements once and then wait on the events to push changes
-    if (this.watchList[layoutState.index]) {
+    if (node.nodeType !== Node.ELEMENT_NODE || this.watchList[nodeLayoutState.index]) {
       return;
     }
 
+    let element = node as Element;
+    let layoutState = nodeLayoutState as IElementLayoutState;
     let scrollPossible = (layoutState.layout
                           && ("scrollX" in layoutState.layout
                           || "scrollY" in layoutState.layout));

--- a/src/plugins/layout/shadowdom.ts
+++ b/src/plugins/layout/shadowdom.ts
@@ -252,7 +252,7 @@ export class ShadowDom {
   }
 
   public createIndexJson(rootNode: Node, getIndexFromNode: (node: Node) => number): NumberJson {
-    let indexJson: NumberJson = {};
+    let indexJson: NumberJson = [];
     this.writeIndexToJson(rootNode, indexJson, getIndexFromNode);
     return indexJson;
   }
@@ -263,9 +263,12 @@ export class ShadowDom {
 
   private writeIndexToJson(node: Node, json: NumberJson, getIndexFromNode: (node: Node) => number) {
     let index = getIndexFromNode(node);
-    let childJson: NumberJson = {};
+    let childJson: number[] = [];
     let nextChild = node.firstChild;
-    json[index] = nextChild ? childJson : null;
+    json.push(index);
+    if (nextChild) {
+      json.push(childJson);
+    }
     while (nextChild) {
       this.writeIndexToJson(nextChild, childJson, getIndexFromNode);
       nextChild = nextChild.nextSibling as IShadowDomNode;

--- a/test/layout.ts
+++ b/test/layout.ts
@@ -885,6 +885,52 @@ describe("Layout Tests", () => {
     }
   });
 
+  it("checks that scroll capturing works on element that enables scrolling after a mutation update", (done: DoneFn) => {
+    let stopObserving = null;
+    let observer = new MutationObserver(callback);
+    let mutationCount = 0;
+    observer.observe(document, { childList: true, subtree: true, attributes: true });
+
+    // Add a scrollable DIV
+    let outerDiv = document.createElement("div");
+    let innerDiv = document.createElement("div");
+    outerDiv.style.overflowY = "visible";
+    outerDiv.style.width = "200px";
+    innerDiv.style.height = "300px";
+    outerDiv.appendChild(innerDiv);
+    document.body.appendChild(outerDiv);
+
+    function callback() {
+      mutationCount++;
+
+      if (mutationCount === 1) {
+        // Make the element scrollable
+        outerDiv.style.maxHeight = "100px";
+        outerDiv.style.overflowY = "hidden";
+        // Force a mutation to ensure that layout updates also capture scroll position
+        outerDiv.setAttribute("data-attribute", "1");
+      } else {
+        observer.disconnect();
+
+        // Add a node to the document and observe Clarity events
+        stopObserving = observeEvents(eventName);
+
+        // Trigger scroll after a mutation update
+        outerDiv.addEventListener("scroll", scrollCallback);
+        outerDiv.scrollTop = 100;
+      }
+    }
+
+    function scrollCallback() {
+      outerDiv.removeEventListener("scroll", scrollCallback);
+      let events = stopObserving();
+      assert.equal(events.length, 1);
+      assert.equal(events[0].state.action, Action.Update);
+      assert.equal(events[0].state.source, Source.Scroll);
+      done();
+    }
+  });
+
   it("checks that input change capturing works on inserted element", (done: DoneFn) => {
     let stopObserving = null;
     let observer = new MutationObserver(callback);


### PR DESCRIPTION
Listen for scroll changes even on dom mutations and not just inserts. This helps to cover cases where element may be added to the DOM one way however updated later to support scrolling using a mutation.

Also changed the format on inconsistent dom nodes. 