### PR TITLE
Samart/expose types

### DIFF
--- a/clarity.d.ts
+++ b/clarity.d.ts
@@ -2,7 +2,7 @@
 /* ############   CONFIG   ############# */
 /* ##################################### */
 
-interface IConfig {
+export interface IConfig {
   // Active plugins
   plugins?: string[];
 
@@ -124,8 +124,8 @@ interface IBindingContainer {
   [key: string]: IEventBindingPair[];
 }
 
-type UploadCallback = (status: number) => void;
-type UploadHandler = (payload: string, onSuccess?: UploadCallback, onFailure?: UploadCallback) => void;
+export type UploadCallback = (status: number) => void;
+export type UploadHandler = (payload: string, onSuccess?: UploadCallback, onFailure?: UploadCallback) => void;
 
 /* ##################################### */
 /* ######   COMPRESSION WORKER   ####### */
@@ -439,7 +439,7 @@ interface IPerformanceResourceTiming {
 /* ############   LIBRARY   ############ */
 /* ##################################### */
 
-interface IClarity {
+export interface IClarity {
   start(config?: IConfig): void;
   stop(): void;
 }

--- a/clarity.d.ts
+++ b/clarity.d.ts
@@ -73,7 +73,7 @@ declare const enum State {
   Unloading
 }
 
-interface IPlugin {
+export interface IPlugin {
   activate(): void;
   teardown(): void;
   reset(): void;
@@ -439,7 +439,5 @@ interface IPerformanceResourceTiming {
 /* ############   LIBRARY   ############ */
 /* ##################################### */
 
-export interface IClarity {
-  start(config?: IConfig): void;
-  stop(): void;
-}
+export function start(config?: IConfig): void;
+export function stop(): void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.2.0",
+  "version": "0.1.20",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/src/clarity.ts
+++ b/src/clarity.ts
@@ -1,3 +1,4 @@
+import { IConfig, State } from "../clarity";
 import { config } from "./config";
 import { activate, onTrigger, state, teardown } from "./core";
 import { mapProperties } from "./utils";

--- a/src/compressionworker.ts
+++ b/src/compressionworker.ts
@@ -1,3 +1,5 @@
+import { IAddEventMessage, ICompressedBatchMessage, IEnvelope, IEvent,
+  Instrumentation, ITimestampedWorkerMessage, WorkerMessageType } from "../clarity";
 import compress from "./compress";
 import { config } from "./config";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { IConfig } from "../clarity";
+
 // Default configuration
 export let config: IConfig = {
   plugins: ["viewport", "layout", "pointer", "performance", "errors"],

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,3 +1,7 @@
+import { IAddEventMessage, IBindingContainer, IClarityActivateErrorState, IClarityDuplicatedEventState, ICompressedBatchMessage,
+  IDroppedPayloadInfo, IEnvelope, IEvent, IEventBindingPair, IEventData, IInstrumentationEventState, IMissingFeatureEventState,
+  Instrumentation, IPayload, IPlugin, ITimestampedWorkerMessage, ITotalByteLimitExceededEventState, IUploadInfo, IXhrErrorEventState,
+  State, UploadCallback, WorkerMessageType } from "../clarity";
 import compress from "./compress";
 import { createCompressionWorker } from "./compressionworker";
 import { config } from "./config";

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,7 +8,7 @@ import { config } from "./config";
 import getPlugin from "./plugins";
 import { debug, getCookie, guid, isNumber, mapProperties, setCookie } from "./utils";
 
-const version = "0.2.0";
+const version = "0.1.20";
 const ImpressionAttribute = "data-iid";
 const UserAttribute = "data-cid";
 const Cookie = "ClarityID";

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,7 +8,7 @@ import { config } from "./config";
 import getPlugin from "./plugins";
 import { debug, getCookie, guid, isNumber, mapProperties, setCookie } from "./utils";
 
-const version = "0.1.19";
+const version = "0.2.0";
 const ImpressionAttribute = "data-iid";
 const UserAttribute = "data-cid";
 const Cookie = "ClarityID";

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,7 +8,7 @@ import { config } from "./config";
 import getPlugin from "./plugins";
 import { debug, getCookie, guid, isNumber, mapProperties, setCookie } from "./utils";
 
-const version = "0.1.20";
+const version = "0.1.21";
 const ImpressionAttribute = "data-iid";
 const UserAttribute = "data-cid";
 const Cookie = "ClarityID";

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,7 @@
 import { IAddEventMessage, IBindingContainer, IClarityActivateErrorState, IClarityDuplicatedEventState, ICompressedBatchMessage,
   IDroppedPayloadInfo, IEnvelope, IEvent, IEventBindingPair, IEventData, IInstrumentationEventState, IMissingFeatureEventState,
-  Instrumentation, IPayload, IPlugin, ITimestampedWorkerMessage, ITotalByteLimitExceededEventState, IUploadInfo, IXhrErrorEventState,
-  State, UploadCallback, WorkerMessageType } from "../clarity";
+  Instrumentation, IPayload, IPlugin, ITimestampedWorkerMessage, ITotalByteLimitExceededEventState, ITriggerState, IUploadInfo,
+  IXhrErrorEventState, State, UploadCallback, WorkerMessageType } from "../clarity";
 import compress from "./compress";
 import { createCompressionWorker } from "./compressionworker";
 import { config } from "./config";

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -1,3 +1,4 @@
+import { IJsErrorEventState, Instrumentation, IPlugin } from "../../clarity";
 import { bind, instrument } from "../core";
 
 export default class ErrorMonitor implements IPlugin {

--- a/src/plugins/layout.ts
+++ b/src/plugins/layout.ts
@@ -1,3 +1,6 @@
+import { Action, IElementLayoutState, IEventData, ILayoutEventInfo, ILayoutRoutineInfo, ILayoutState, IMutationRoutineInfo,
+  Instrumentation, IPlugin, IShadowDomInconsistentEventState, IShadowDomMutationSummary, IShadowDomNode, LayoutRoutine,
+  NumberJson, Source } from "../../clarity";
 import { config } from "./../config";
 import { addEvent, addMultipleEvents, bind, getTimestamp, instrument } from "./../core";
 import { debug, isNumber, traverseNodeTree } from "./../utils";

--- a/src/plugins/layout/shadowdom.ts
+++ b/src/plugins/layout/shadowdom.ts
@@ -1,3 +1,4 @@
+import { IShadowDomMutationSummary, IShadowDomNode, NumberJson } from "../../../clarity";
 import { assert, isNumber, traverseNodeTree } from "../../utils";
 import { getNodeIndex, NodeIndex, shouldIgnoreNode } from "./stateprovider";
 

--- a/src/plugins/layout/stateprovider.ts
+++ b/src/plugins/layout/stateprovider.ts
@@ -1,3 +1,5 @@
+import { IAttributes, IDoctypeLayoutState, IElementLayoutState,
+   IIgnoreLayoutState, ILayoutState, ITextLayoutState } from "../../../clarity";
 import { config } from "../../config";
 import { assert } from "../../utils";
 import { ShadowDom } from "./shadowdom";

--- a/src/plugins/performance.ts
+++ b/src/plugins/performance.ts
@@ -1,3 +1,4 @@
+import { IPerformanceResourceTiming, IPlugin } from "../../clarity";
 import { config } from "../config";
 import { addEvent, instrument } from "../core";
 import { mapProperties } from "../utils";

--- a/src/plugins/pointer.ts
+++ b/src/plugins/pointer.ts
@@ -1,3 +1,4 @@
+import { IPlugin, IPointerModule, IPointerState } from "../../clarity";
 import { addEvent, bind } from "../core";
 import * as mouse from "./pointer/mouse";
 import * as touch from "./pointer/touch";

--- a/src/plugins/pointer/mouse.ts
+++ b/src/plugins/pointer/mouse.ts
@@ -1,3 +1,4 @@
+import { IPointerState } from "../../../clarity";
 import { NodeIndex } from "../layout/stateprovider";
 
 export function transform(evt: MouseEvent): IPointerState[] {

--- a/src/plugins/pointer/touch.ts
+++ b/src/plugins/pointer/touch.ts
@@ -1,3 +1,4 @@
+import { IPointerState } from "../../../clarity";
 import { NodeIndex } from "../layout/stateprovider";
 
 export function transform(evt: TouchEvent): IPointerState[] {

--- a/src/plugins/viewport.ts
+++ b/src/plugins/viewport.ts
@@ -1,3 +1,4 @@
+import { IPlugin, IViewportState } from "../../clarity";
 import { addEvent, bind } from "../core";
 
 export default class Viewport implements IPlugin {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { IClarityAssertFailedEventState, Instrumentation } from "../clarity";
 import { config } from "./config";
 import { instrument } from "./core";
 

--- a/test/clarity.ts
+++ b/test/clarity.ts
@@ -1,5 +1,4 @@
-import { IConfig } from "../clarity";
-import { start } from "../src/clarity";
+import { IConfig, start } from "../clarity";
 import { config } from "../src/config";
 
 // Make config uri non-empty, so that Clarity executes send

--- a/test/clarity.ts
+++ b/test/clarity.ts
@@ -1,5 +1,5 @@
-import { IConfig, start } from "../clarity";
-import { config } from "../src/config";
+import { IConfig } from "../clarity";
+import { start } from "../src/clarity";
 
 // Make config uri non-empty, so that Clarity executes send
 // Allow instrumentation events

--- a/test/clarity.ts
+++ b/test/clarity.ts
@@ -1,3 +1,4 @@
+import { IConfig } from "../clarity";
 import { start } from "../src/clarity";
 import { config } from "../src/config";
 

--- a/test/compressionworker.ts
+++ b/test/compressionworker.ts
@@ -1,3 +1,5 @@
+import { IAddEventMessage, ICompressedBatchMessage, IEvent, Instrumentation,
+  ITimestampedWorkerMessage, IWorkerMessage, IXhrErrorEventState, WorkerMessageType } from "../clarity";
 import { createCompressionWorker } from "./../src/compressionworker";
 import { config } from "./../src/config";
 import * as core from "./../src/core";

--- a/test/core.ts
+++ b/test/core.ts
@@ -1,3 +1,4 @@
+import { ICompressedBatchMessage, IEvent, Instrumentation, State, UploadCallback, WorkerMessageType } from "../clarity";
 import { config } from "../src/config";
 import * as core from "../src/core";
 import { activateCore, cleanupFixture, getSentEvents, setupFixture } from "./testsetup";

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -2,6 +2,7 @@ import { cleanupFixture, setupFixture } from "./testsetup";
 import { observeEvents } from "./utils";
 
 import * as chai from "chai";
+import { Instrumentation } from "../clarity";
 import * as errors from "../src/plugins/errors";
 
 let assert = chai.assert;

--- a/test/layout.ts
+++ b/test/layout.ts
@@ -1,3 +1,4 @@
+import { Action, IEvent, Source } from "../clarity";
 import { start, stop } from "../src/clarity";
 import { config } from "../src/config";
 import * as core from "../src/core";

--- a/test/testsetup.ts
+++ b/test/testsetup.ts
@@ -1,3 +1,4 @@
+import { IAddEventMessage, IConfig, IWorkerMessage, WorkerMessageType } from "../clarity";
 import { start, stop } from "../src/clarity";
 import { config } from "../src/config";
 import { guid, mapProperties } from "../src/utils";

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,5 @@
 
+import { ICompressedBatchMessage, IEnvelope, IEvent, IWorkerMessage, WorkerMessageType } from "../clarity";
 import compress from "../src/compress";
 import { addEvent, onWorkerMessage } from "../src/core";
 import { guid } from "../src/utils";


### PR DESCRIPTION
Updating how we expose types so other typescript projects can make strongly typed references to Clarity.

Bumping version as import * as clarity from "clarity-js" to do clarity.start() is changing to import {start} from "clarity-js"