### PR TITLE
Split umbrella 'types' imports into distinct module imports

### DIFF
--- a/src/clarity.ts
+++ b/src/clarity.ts
@@ -1,8 +1,8 @@
-import { IConfig, State } from "../types/index";
+import { IConfig } from "../types/config";
+import { State } from "../types/core";
 import { config } from "./config";
 import { activate, onTrigger, state, teardown } from "./core";
 import { mapProperties } from "./utils";
-
 export { version } from "./core";
 
 export function start(customConfig?: IConfig) {

--- a/src/compressionworker.ts
+++ b/src/compressionworker.ts
@@ -1,7 +1,8 @@
-import { IAddEventMessage, ICompressedBatchMessage, IEnvelope, IEventArray, IPayload,
-  ITimestampedWorkerMessage, WorkerMessageType } from "../types/index";
-import Compress from "./compress";
+import { IAddEventMessage, ICompressedBatchMessage, ITimestampedWorkerMessage, WorkerMessageType } from "../types/compressionworker";
+import { IEnvelope, IEventArray, IPayload } from "../types/core";
 import { config as Config } from "./config";
+
+import Compress from "./compress";
 
 export function createCompressionWorker(
   envelope: IEnvelope,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { IConfig } from "../types/index";
+import { IConfig } from "../types/config";
 
 // Default configuration
 export let config: IConfig = {

--- a/src/converters/fromarray.ts
+++ b/src/converters/fromarray.ts
@@ -1,6 +1,6 @@
-import { ObjectType } from "../../types/index";
-import {  IEvent, IEventArray } from "../../types/index";
+import { IEvent, IEventArray, ObjectType } from "../../types/core";
 import { SchemaManager } from "./schema";
+
 import defaultSchemas from "./schema";
 
 export default function(eventArray: IEventArray, schemas?: SchemaManager): IEvent {

--- a/src/converters/schema.ts
+++ b/src/converters/schema.ts
@@ -1,4 +1,4 @@
-import { ClarityDataSchema, ObjectType } from "../../types/index";
+import { ClarityDataSchema, ObjectType } from "../../types/core";
 
 // Details about schema generation are in schema.md:
 // https://github.com/Microsoft/clarity-js/blob/master/converters/schema.md

--- a/src/converters/toarray.ts
+++ b/src/converters/toarray.ts
@@ -1,4 +1,4 @@
-import { IEvent, IEventArray } from "../../types/index";
+import { IEvent, IEventArray } from "../../types/core";
 import schemas from "./schema";
 
 // We serialize send a lot of JSONs with identical structures and putting all property names on the

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,23 +1,10 @@
 import { IAddEventMessage, ICompressedBatchMessage, ITimestampedWorkerMessage, WorkerMessageType } from "../types/compressionworker";
 import {
-  IBindingContainer,
-  IClarityFields,
-  IEnvelope,
-  IEvent,
-  IEventArray,
-  IEventBindingPair,
-  IEventData,
-  IPayload,
-  IPlugin,
-  State
+  IBindingContainer, IClarityFields, IEnvelope, IEvent, IEventArray, IEventBindingPair, IEventData, IPayload, IPlugin, State
 } from "../types/core";
 import {
-  IClarityActivateErrorState,
-  IClarityDuplicatedEventState,
-  IInstrumentationEventState,
-  IMissingFeatureEventState,
-  Instrumentation,
-  ITriggerState
+  IClarityActivateErrorState, IClarityDuplicatedEventState, IInstrumentationEventState,
+  IMissingFeatureEventState, Instrumentation, ITriggerState
 } from "../types/instrumentation";
 import { createCompressionWorker } from "./compressionworker";
 import { config } from "./config";

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,15 +1,33 @@
-import { IAddEventMessage, IBindingContainer, IClarityActivateErrorState, IClarityDuplicatedEventState, IClarityFields,
-  ICompressedBatchMessage, IEnvelope, IEvent, IEventArray, IEventBindingPair, IEventData,
-  IInstrumentationEventState, IMissingFeatureEventState, Instrumentation, IPayload, IPlugin, ITimestampedWorkerMessage,
-  ITriggerState, State, WorkerMessageType } from "../types/index";
-import compress from "./compress";
+import { IAddEventMessage, ICompressedBatchMessage, ITimestampedWorkerMessage, WorkerMessageType } from "../types/compressionworker";
+import {
+  IBindingContainer,
+  IClarityFields,
+  IEnvelope,
+  IEvent,
+  IEventArray,
+  IEventBindingPair,
+  IEventData,
+  IPayload,
+  IPlugin,
+  State
+} from "../types/core";
+import {
+  IClarityActivateErrorState,
+  IClarityDuplicatedEventState,
+  IInstrumentationEventState,
+  IMissingFeatureEventState,
+  Instrumentation,
+  ITriggerState
+} from "../types/instrumentation";
 import { createCompressionWorker } from "./compressionworker";
 import { config } from "./config";
 import { resetSchemas } from "./converters/schema";
-import EventToArray from "./converters/toarray";
-import getPlugin from "./plugins";
 import { enqueuePayload, flushPayloadQueue, resetUploads, upload } from "./upload";
 import { getCookie, getEventId, guid, isNumber, setCookie } from "./utils";
+
+import compress from "./compress";
+import EventToArray from "./converters/toarray";
+import getPlugin from "./plugins";
 
 export const version = "0.2.8";
 export const ClarityAttribute = "clarity-iid";

--- a/src/plugins/errors.ts
+++ b/src/plugins/errors.ts
@@ -1,4 +1,5 @@
-import { IJsErrorEventState, Instrumentation, IPlugin } from "../../types/index";
+import { IPlugin } from "../../types/core";
+import { IJsErrorEventState, Instrumentation } from "../../types/instrumentation";
 import { bind, instrument } from "../core";
 
 export default class ErrorMonitor implements IPlugin {

--- a/src/plugins/layout.ts
+++ b/src/plugins/layout.ts
@@ -1,19 +1,8 @@
 import { IEventData, IPlugin } from "../../types/core";
 import { Instrumentation, IShadowDomInconsistentEventState } from "../../types/instrumentation";
 import {
-  Action,
-  IElementLayoutState,
-  ILayoutRoutineInfo,
-  ILayoutState,
-  IMutationRoutineInfo,
-  INodeInfo,
-  InsertRuleHandler,
-  IShadowDomMutationSummary,
-  IShadowDomNode,
-  IStyleLayoutState,
-  LayoutRoutine,
-  NumberJson,
-  Source
+  Action, IElementLayoutState, ILayoutRoutineInfo, ILayoutState, IMutationRoutineInfo, INodeInfo, InsertRuleHandler,
+  IShadowDomMutationSummary, IShadowDomNode, IStyleLayoutState, LayoutRoutine, NumberJson, Source
 } from "../../types/layout";
 import { config } from "./../config";
 import { addEvent, addMultipleEvents, bind, getTimestamp, instrument } from "./../core";

--- a/src/plugins/layout.ts
+++ b/src/plugins/layout.ts
@@ -1,6 +1,20 @@
-import { Action, IElementLayoutState, IEventData, ILayoutRoutineInfo, ILayoutState, IMutationRoutineInfo,
-  INodeInfo, InsertRuleHandler, Instrumentation, IPlugin, IShadowDomInconsistentEventState, IShadowDomMutationSummary, IShadowDomNode,
-  IStyleLayoutState, LayoutRoutine, NumberJson, Source } from "../../types/index";
+import { IEventData, IPlugin } from "../../types/core";
+import { Instrumentation, IShadowDomInconsistentEventState } from "../../types/instrumentation";
+import {
+  Action,
+  IElementLayoutState,
+  ILayoutRoutineInfo,
+  ILayoutState,
+  IMutationRoutineInfo,
+  INodeInfo,
+  InsertRuleHandler,
+  IShadowDomMutationSummary,
+  IShadowDomNode,
+  IStyleLayoutState,
+  LayoutRoutine,
+  NumberJson,
+  Source
+} from "../../types/layout";
 import { config } from "./../config";
 import { addEvent, addMultipleEvents, bind, getTimestamp, instrument } from "./../core";
 import { debug, mask, traverseNodeTree } from "./../utils";

--- a/src/plugins/layout/nodeinfo.ts
+++ b/src/plugins/layout/nodeinfo.ts
@@ -1,4 +1,4 @@
-import { ILayoutState, INodeInfo } from "../../../types/index";
+import { ILayoutState, INodeInfo } from "../../../types/layout";
 import { createLayoutState, getNodeIndex, Tags } from "./stateprovider";
 
 export const ForceMaskAttribute = "data-clarity-mask";

--- a/src/plugins/layout/shadowdom.ts
+++ b/src/plugins/layout/shadowdom.ts
@@ -1,4 +1,4 @@
-import { INodeInfo, IShadowDomMutationSummary, IShadowDomNode, NumberJson } from "../../../types/index";
+import { INodeInfo, IShadowDomMutationSummary, IShadowDomNode, NumberJson } from "../../../types/layout";
 import { assert, isNumber, traverseNodeTree } from "../../utils";
 import { createNodeInfo } from "./nodeinfo";
 import { getNodeIndex, NodeIndex } from "./stateprovider";

--- a/src/plugins/layout/stateprovider.ts
+++ b/src/plugins/layout/stateprovider.ts
@@ -1,5 +1,13 @@
-import { IAttributes, IDoctypeLayoutState, IElementLayoutState, IIgnoreLayoutState, ILayoutRectangle, ILayoutState, IStyleLayoutState,
-  ITextLayoutState } from "../../../types/index";
+import {
+  IAttributes,
+  IDoctypeLayoutState,
+  IElementLayoutState,
+  IIgnoreLayoutState,
+  ILayoutRectangle,
+  ILayoutState,
+  IStyleLayoutState,
+  ITextLayoutState
+} from "../../../types/layout";
 import { config } from "../../config";
 import { mask } from "../../utils";
 

--- a/src/plugins/layout/stateprovider.ts
+++ b/src/plugins/layout/stateprovider.ts
@@ -1,12 +1,6 @@
 import {
-  IAttributes,
-  IDoctypeLayoutState,
-  IElementLayoutState,
-  IIgnoreLayoutState,
-  ILayoutRectangle,
-  ILayoutState,
-  IStyleLayoutState,
-  ITextLayoutState
+  IAttributes, IDoctypeLayoutState, IElementLayoutState, IIgnoreLayoutState,
+  ILayoutRectangle, ILayoutState, IStyleLayoutState, ITextLayoutState
 } from "../../../types/layout";
 import { config } from "../../config";
 import { mask } from "../../utils";

--- a/src/plugins/performance.ts
+++ b/src/plugins/performance.ts
@@ -1,4 +1,5 @@
-import { IPerformanceResourceTimingState, IPerformanceTimingState, IPlugin } from "../../types/index";
+import { IPlugin } from "../../types/core";
+import { IPerformanceResourceTimingState, IPerformanceTimingState } from "../../types/performance";
 import { config } from "../config";
 import { addEvent } from "../core";
 import { mapProperties } from "../utils";

--- a/src/plugins/pointer.ts
+++ b/src/plugins/pointer.ts
@@ -1,7 +1,9 @@
-import { IPlugin, IPointerModule, IPointerState } from "../../types/index";
-import { addEvent, bind } from "../core";
 import * as mouse from "./pointer/mouse";
 import * as touch from "./pointer/touch";
+
+import { IPlugin } from "../../types/core";
+import { IPointerModule, IPointerState } from "../../types/pointer";
+import { addEvent, bind } from "../core";
 
 export default class Pointer implements IPlugin {
   private eventName = "Pointer";

--- a/src/plugins/pointer/mouse.ts
+++ b/src/plugins/pointer/mouse.ts
@@ -1,4 +1,4 @@
-import { IPointerState } from "../../../types/index";
+import { IPointerState } from "../../../types/pointer";
 import { NodeIndex } from "../layout/stateprovider";
 
 // Accessing any evt property can sometimes (rarely) throw exception "Permission denied to access property..."

--- a/src/plugins/pointer/touch.ts
+++ b/src/plugins/pointer/touch.ts
@@ -1,4 +1,4 @@
-import { IPointerState } from "../../../types/index";
+import { IPointerState } from "../../../types/pointer";
 import { NodeIndex } from "../layout/stateprovider";
 
 // Accessing any evt property can sometimes (rarely) throw exception "Permission denied to access property..."

--- a/src/plugins/viewport.ts
+++ b/src/plugins/viewport.ts
@@ -1,4 +1,5 @@
-import { IPlugin, IViewportState } from "../../types/index";
+import { IPlugin } from "../../types/core";
+import { IViewportState } from "../../types/viewport";
 import { addEvent, bind } from "../core";
 
 export default class Viewport implements IPlugin {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,5 @@
-import { Instrumentation, IPayload, IPayloadInfo, ITotalByteLimitExceededEventState, IXhrErrorEventState,
-  State, UploadCallback } from "../types/index";
+import { IPayload, IPayloadInfo, State, UploadCallback } from "../types/core";
+import { Instrumentation, ITotalByteLimitExceededEventState, IXhrErrorEventState } from "../types/instrumentation";
 import { config } from "./config";
 import { ClarityAttribute, instrument, state, teardown } from "./core";
 import { debug, getEventId } from "./utils";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { IClarityAssertFailedEventState, IEventArray, Instrumentation } from "../types/index";
+import { IEventArray } from "../types/core";
+import { IClarityAssertFailedEventState, Instrumentation } from "../types/instrumentation";
 import { config } from "./config";
 import { instrument } from "./core";
 

--- a/test/clarity.ts
+++ b/test/clarity.ts
@@ -1,5 +1,5 @@
 import { start } from "../src/clarity";
-import { IConfig } from "../types/index";
+import { IConfig } from "../types/config";
 
 // Make config uri non-empty, so that Clarity executes send
 // Allow instrumentation events

--- a/test/compressionworker.ts
+++ b/test/compressionworker.ts
@@ -1,12 +1,20 @@
-import { IAddEventMessage, ICompressedBatchMessage, IEvent, Instrumentation,
-  ITimestampedWorkerMessage, IWorkerMessage, IXhrErrorEventState, WorkerMessageType } from "../types/index";
+import * as chai from "chai";
+
+import {
+  IAddEventMessage,
+  ICompressedBatchMessage,
+  ITimestampedWorkerMessage,
+  IWorkerMessage,
+  WorkerMessageType
+} from "../types/compressionworker";
+import { IEvent } from "../types/core";
+import { Instrumentation, IXhrErrorEventState } from "../types/instrumentation";
 import { createCompressionWorker } from "./../src/compressionworker";
 import { config } from "./../src/config";
 import { cleanupFixture, setupFixture } from "./testsetup";
-import MockEventToArray from "./toarray";
 import { getMockEnvelope, getMockEvent, MockEventName, payloadToEvents } from "./utils";
 
-import * as chai from "chai";
+import MockEventToArray from "./toarray";
 
 const InstrumentationEventName = "Instrumentation";
 const WorkerMessageWaitTime = 1000;

--- a/test/compressionworker.ts
+++ b/test/compressionworker.ts
@@ -1,11 +1,7 @@
 import * as chai from "chai";
 
 import {
-  IAddEventMessage,
-  ICompressedBatchMessage,
-  ITimestampedWorkerMessage,
-  IWorkerMessage,
-  WorkerMessageType
+  IAddEventMessage, ICompressedBatchMessage, ITimestampedWorkerMessage, IWorkerMessage, WorkerMessageType
 } from "../types/compressionworker";
 import { IEvent } from "../types/core";
 import { Instrumentation, IXhrErrorEventState } from "../types/instrumentation";

--- a/test/convert.ts
+++ b/test/convert.ts
@@ -1,9 +1,11 @@
+import * as chai from "chai";
+
 import FromArray from "../src/converters/fromarray";
 import ToArray from "../src/converters/toarray";
-import { IEvent } from "../types/index";
 
-import * as chai from "chai";
+import { IEvent } from "../types/core";
 import { getMockEvent } from "./utils";
+
 let assert = chai.assert;
 
 describe("Data Conversion Tests", () => {

--- a/test/core.ts
+++ b/test/core.ts
@@ -1,11 +1,15 @@
-import { config } from "../src/config";
+import * as chai from "chai";
 import * as core from "../src/core";
-import { ICompressedBatchMessage, IEnvelope, IEventArray, Instrumentation, IPayload, State, WorkerMessageType } from "../types/index";
-import { activateCore, cleanupFixture, getSentEvents, setupFixture } from "./testsetup";
+
 import uncompress from "./uncompress";
+
+import { config } from "../src/config";
+import { ICompressedBatchMessage, WorkerMessageType } from "../types/compressionworker";
+import { IEnvelope, IEventArray, IPayload, State } from "../types/core";
+import { Instrumentation } from "../types/instrumentation";
+import { activateCore, cleanupFixture, getSentEvents, setupFixture } from "./testsetup";
 import { getMockEvent, MockEventName, observeEvents, observeWorkerMessages, payloadToEvents } from "./utils";
 
-import * as chai from "chai";
 let assert = chai.assert;
 
 describe("Core Tests", () => {

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -1,9 +1,9 @@
-import { cleanupFixture, setupFixture } from "./testsetup";
-import { observeEvents } from "./utils";
-
 import * as chai from "chai";
 import * as errors from "../src/plugins/errors";
-import { Instrumentation } from "../types/index";
+
+import { Instrumentation } from "../types/instrumentation";
+import { cleanupFixture, setupFixture } from "./testsetup";
+import { observeEvents } from "./utils";
 
 let assert = chai.assert;
 

--- a/test/fromarray.ts
+++ b/test/fromarray.ts
@@ -1,5 +1,6 @@
 import EventFromArray from "../src/converters/fromarray";
-import { IEvent, IEventArray } from "../types/index";
+
+import { IEvent, IEventArray } from "../types/core";
 import { MockEventName } from "./utils";
 
 export default function(eventArray: IEventArray): IEvent {

--- a/test/layout.ts
+++ b/test/layout.ts
@@ -1,13 +1,14 @@
-import { config } from "../src/config";
+import * as chai from "chai";
 import * as core from "../src/core";
+
+import { config } from "../src/config";
+import { ForceMaskAttribute } from "../src/plugins/layout/nodeinfo";
 import { NodeIndex, Tags } from "../src/plugins/layout/stateprovider";
 import { mask } from "../src/utils";
-import { Action, IEvent, Source } from "../types/index";
+import { IEvent } from "../types/core";
+import { Action, Source } from "../types/layout";
 import { activateCore, cleanupFixture, setupFixture } from "./testsetup";
 import { observeEvents } from "./utils";
-
-import * as chai from "chai";
-import { ForceMaskAttribute } from "../src/plugins/layout/nodeinfo";
 
 let eventName = "Layout";
 let assert = chai.assert;

--- a/test/testsetup.ts
+++ b/test/testsetup.ts
@@ -1,9 +1,12 @@
+import EventFromArray from "./fromarray";
+
 import { start, stop } from "../src/clarity";
 import { config } from "../src/config";
 import { mapProperties } from "../src/utils";
-import { IAddEventMessage, IConfig, IEvent, IWorkerMessage, WorkerMessageType } from "../types/index";
+import { IAddEventMessage, IWorkerMessage, WorkerMessageType } from "../types/compressionworker";
+import { IConfig } from "../types/config";
+import { IEvent } from "../types/core";
 import { testConfig } from "./clarity";
-import EventFromArray from "./fromarray";
 
 declare var fixture;
 

--- a/test/toarray.ts
+++ b/test/toarray.ts
@@ -1,5 +1,6 @@
 import EventToArray from "../src/converters/toarray";
-import { IEvent, IEventArray } from "../types/index";
+
+import { IEvent, IEventArray } from "../types/core";
 import { MockEventName } from "./utils";
 
 export default function(event: IEvent): IEventArray {

--- a/test/upload.ts
+++ b/test/upload.ts
@@ -1,14 +1,15 @@
-import { config } from "../src/config";
-import * as core from "../src/core";
-import { getEventType } from "../src/utils";
-import { Instrumentation, State, UploadCallback } from "../types/index";
-import { activateCore, cleanupFixture, setupFixture } from "./testsetup";
-import uncompress from "./uncompress";
-import {
-  getMockEnvelope, getMockEvent, observeEvents, postCompressedBatch
-} from "./utils";
-
 import * as chai from "chai";
+import * as core from "../src/core";
+
+import uncompress from "./uncompress";
+
+import { config } from "../src/config";
+import { getEventType } from "../src/utils";
+import { State, UploadCallback } from "../types/core";
+import { Instrumentation } from "../types/instrumentation";
+import { activateCore, cleanupFixture, setupFixture } from "./testsetup";
+import { getMockEnvelope, getMockEvent, observeEvents, postCompressedBatch } from "./utils";
+
 let assert = chai.assert;
 
 describe("Data Upload Tests", () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,11 +1,13 @@
 
 import compress from "../src/compress";
+import EventFromArray from "./fromarray";
+import EventToArray from "./toarray";
+
 import { onWorkerMessage } from "../src/core";
 import { guid } from "../src/utils";
-import { ICompressedBatchMessage, IEnvelope, IEvent, IEventArray, IPayload, IWorkerMessage, WorkerMessageType } from "../types/index";
-import EventFromArray from "./fromarray";
+import { ICompressedBatchMessage, IWorkerMessage, WorkerMessageType } from "../types/compressionworker";
+import { IEnvelope, IEvent, IEventArray, IPayload } from "../types/core";
 import { getSentEvents, getWorkerMessages } from "./testsetup";
-import EventToArray from "./toarray";
 
 export const MockEventName = "ClarityTestMockEvent";
 


### PR DESCRIPTION
Purely housekeeping work. Having imports from particular modules rather than from a single unified 'types' module, makes reading and understand cross-modules dependencies easier.