### PR TITLE
 Subscribe to watch for scroll/change/input on elements during 'discover' phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/src/core.ts
+++ b/src/core.ts
@@ -16,7 +16,7 @@ import { resetSchemas } from "./converters/schema";
 import { enqueuePayload, flushPayloadQueue, resetUploads, upload } from "./upload";
 import { getCookie, getEventId, guid, isNumber, setCookie } from "./utils";
 
-export const version = "0.2.8";
+export const version = "0.2.9";
 export const ClarityAttribute = "clarity-iid";
 export const InstrumentationEventName = "Instrumentation";
 const Cookie = "ClarityID";

--- a/src/plugins/layout.ts
+++ b/src/plugins/layout.ts
@@ -115,7 +115,9 @@ export default class Layout implements IPlugin {
   // Add node to the ShadowDom to store initial adjacent node info in a layout and obtain an index
   private discoverNode(node: Node): INodeInfo {
     let shadowNode = this.shadowDom.insertShadowNode(node, getNodeIndex(node.parentNode), getNodeIndex(node.nextSibling));
-    return shadowNode.computeInfo();
+    let nodeInfo = shadowNode.computeInfo();
+    this.watch(node, nodeInfo.state);
+    return nodeInfo;
   }
 
   private watch(node: Node, nodeLayoutState: ILayoutState) {


### PR DESCRIPTION
We were only calling 'watch' method on nodes added through mutations on the page. Nodes that were already on the page when Clarity activates never got their event listeners attached, so we were failing to observe scrolls/inputs/change on those elements.