### PR TITLE
Ping timeout callback

### DIFF
--- a/src/clarity.ts
+++ b/src/clarity.ts
@@ -22,12 +22,12 @@ export function start(override: Config = {}): void {
   if (core.check()) {
     config(override);
     status = true;
-
     core.start();
     data.start();
     diagnostic.start();
     layout.start();
     interaction.start();
+    data.setPingTimeoutCallback(pause);
   }
 }
 
@@ -38,6 +38,7 @@ export function pause(): void {
   bind(window, "resize", resume);
   bind(window, "scroll", resume);
   bind(window, "pageshow", resume);
+
 }
 
 export function resume(): void {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -20,3 +20,7 @@ export function end(): void {
     metadata.end();
     metric.end();
 }
+
+export function setPingTimeoutCallback(callback: VoidFunction): void {
+    ping.setTimeoutCallback(callback);
+}

--- a/src/data/ping.ts
+++ b/src/data/ping.ts
@@ -1,5 +1,4 @@
 import { Event, PingData } from "@clarity-types/data";
-import { pause } from "@src/clarity";
 import config from "@src/core/config";
 import time from "@src/core/time";
 import encode from "./encode";
@@ -8,7 +7,7 @@ export let data: PingData;
 let last = 0;
 let interval = 0;
 let timeout: number = null;
-
+let onTimeout: VoidFunction = null;
 export function start(): void {
     interval = config.ping;
 }
@@ -18,6 +17,10 @@ export function reset(): void {
     timeout = window.setTimeout(ping, interval);
 }
 
+export function setTimeoutCallback(onTimeoutCallback: VoidFunction): void {
+    onTimeout = onTimeoutCallback;
+}
+
 function ping(): void {
     let now = time();
     data = { gap: now - last };
@@ -25,8 +28,9 @@ function ping(): void {
     if (data.gap < config.timeout) {
         interval = Math.min(interval * 2, config.timeout);
         timeout = window.setTimeout(ping, interval);
-    } else { pause(); }
-
+    } else {
+        if (onTimeout) onTimeout();
+    }
     last = now;
 }
 

--- a/src/data/ping.ts
+++ b/src/data/ping.ts
@@ -29,7 +29,7 @@ function ping(): void {
         interval = Math.min(interval * 2, config.timeout);
         timeout = window.setTimeout(ping, interval);
     } else {
-        if (onTimeout) onTimeout();
+        if (onTimeout) { onTimeout(); }
     }
     last = now;
 }


### PR DESCRIPTION
Added on clarity on Start function: 
	data.setPingTimeoutCallback(pause);
This makes it clear that pause is called by data, when a timeout occurs with the ping.

Removed the dependency of clarity from ping.
